### PR TITLE
[BUGFIX] Error at end of warmup timer

### DIFF
--- a/ci/ubuntu-buildgen.sh
+++ b/ci/ubuntu-buildgen.sh
@@ -11,10 +11,10 @@ set -x
 sudo apt update
 if [[ -z ${USE_SDL12:-} ]]; then
     sudo apt install ninja-build libsdl2-dev libsdl2-mixer-dev \
-        libcurl4-openssl-dev libwxgtk3.0-gtk3-dev deutex
+        libcurl4-openssl-dev libwxgtk3.2-dev deutex
 else
     sudo apt install ninja-build libsdl1.2-dev libsdl-mixer1.2-dev \
-        libcurl4-openssl-dev libwxgtk3.0-gtk3-dev deutex
+        libcurl4-openssl-dev libwxgtk3.2-dev deutex
 fi
 
 # Generate build

--- a/common/info.h
+++ b/common/info.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -49,7 +49,7 @@ typedef enum spritenum_e: int32_t
     SPR_GIB7,
     // [RH] Dummy for unknown mapthing
     SPR_UNKN,
-        
+
     //    [Toke - CTF]
     SPR_BSOK,
     SPR_RSOK,
@@ -64,7 +64,7 @@ typedef enum spritenum_e: int32_t
     SPR_GFLG,
     SPR_GDWN,
     SPR_GCAR,
-    
+
     SPR_TLGL,
 
     SPR_WPBF,
@@ -1313,7 +1313,7 @@ typedef enum statenum_e: int32_t
 	S_TECH2LAMP3,
 	S_TECH2LAMP4,
 
-	S_TNT1, // add state for invisible sprite         // phares 3/8/98 
+	S_TNT1, // add state for invisible sprite         // phares 3/8/98
 
 	S_GRENADE,   // killough 8/9/98: grenade launcher
 	S_DETONATE,  // killough 8/9/98: detonation of objects
@@ -1347,11 +1347,11 @@ typedef enum statenum_e: int32_t
 	S_DOGS_RAISE4,
 	S_DOGS_RAISE5,
 	S_DOGS_RAISE6,
-	
+
 	S_OLDBFG1,  // killough 7/11/98: the old BFG's 43 firing frames
 	S_OLDBFG42 = S_OLDBFG1 + 41,
 	S_OLDBFG43,
-	
+
 
 	S_PLS1BALL,      // killough 7/19/98: first plasma fireball in the beta
 	S_PLS1BALL2,
@@ -1438,9 +1438,9 @@ extern state_t odastates[];
 inline FArchive &operator<< (FArchive &arc, state_t *state)
 {
 	if (state)
-		return arc << (WORD)(state->statenum);
+		return arc << (int32_t)(state->statenum);
 	else
-		return arc << (WORD)0xffff;
+		return arc << (int32_t)0xffffffff;
 }
 
 inline FArchive &operator>> (FArchive &arc, state_t *&state)
@@ -1456,9 +1456,9 @@ inline FArchive &operator>> (FArchive &arc, state_t *&state)
 }
 
 typedef enum mobjtype_e: int32_t {
-    
+
     // -------------------- odamex things ----------------------------------- //
-    
+
     // [RH] Gibs (code is disabled)
     MT_GIB0 = -2147483647,
     MT_GIB1,
@@ -1491,7 +1491,7 @@ typedef enum mobjtype_e: int32_t {
     MT_BCAR,
     MT_RCAR,
     // -----------------------------------
-    
+
     MT_BRIDGE,
     MT_MAPSPOT,
     MT_MAPSPOTGRAVITY,
@@ -1523,7 +1523,7 @@ typedef enum mobjtype_e: int32_t {
     MT_AVATAR,
     MT_HORDESPAWN,
     MT_CAREPACK,
-    
+
     // --------------------------------------------------------------------- //
 
 	MT_NULL = -1, // ferk: null/invalid mobj (zero is reserved for MT_PLAYER)
@@ -1759,7 +1759,7 @@ typedef struct _mobjinfo
 	int damage;
 	const char *activesound;	// [RH] not int
 	int flags;
-	int flags2;	
+	int flags2;
 	statenum_t raisestate;
 	int translucency;
 	const char *name;
@@ -1786,9 +1786,9 @@ extern DoomObjectContainer<mobjinfo_t*> spawn_map; // int
 inline FArchive &operator<< (FArchive &arc, mobjinfo_t *info)
 {
 	if (info)
-		return arc << (WORD)(info->type);
+		return arc << (int32_t)(info->type);
 	else
-		return arc << (WORD)0xffff;
+		return arc << (int32_t)0xffffffff;
 }
 
 inline FArchive &operator>> (FArchive &arc, mobjinfo_t *&info)


### PR DESCRIPTION
`FArchive::operator>>` and `FArchive::operator<<` for `mobjinfo_t` and `state_t` did not read/write the same number of bytes, resulting in more bytes being read than were written.